### PR TITLE
Enable database configuration

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,3 +1,8 @@
 server:
   # defines the port the server is listening to. Default is 8080
   port: 8080
+database:
+  # defines the path where the database file is created and used
+  # to store the persistent state of the service
+  path: ./coffy_machine.db
+

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -19,7 +19,7 @@ coffy-server is the heart of the coffy-suite and comes with a HTTP REST interfac
 }
 
 func init() {
-	serverCmd.Flags().StringVarP(&cfgPath, "config", "c", "./coffy.yaml", "path to coffy-server.yaml")
+	serverCmd.Flags().StringVarP(&cfgPath, "config", "c", "./coffy.yaml", "path to coffy_machine.yaml")
 }
 
 func run(cmd *cobra.Command, args []string) {

--- a/internal/coffy/config.go
+++ b/internal/coffy/config.go
@@ -34,7 +34,25 @@ func validateConfig(cfg *Config) error {
 	if cfg == nil {
 		return errors.New("config is nil")
 	}
-	return validateServer(cfg.Server)
+
+	if err := validateServer(cfg.Server); err != nil {
+		return err
+	}
+
+	if err := validateDatabase(cfg.Database); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateDatabase(c *DbCfg) error {
+	if c == nil {
+		return MissingPropertyError{"database", "missing property"}
+	}
+	if c.Path == "" {
+		return MissingPropertyError{"path", "missing property"}
+	}
+	return nil
 }
 
 func validateServer(s *ServerCfg) error {
@@ -48,11 +66,16 @@ func validateServer(s *ServerCfg) error {
 }
 
 type Config struct {
-	Server *ServerCfg `yaml:"server"`
+	Server   *ServerCfg `yaml:"server"`
+	Database *DbCfg     `yaml:"database"`
 }
 
 type ServerCfg struct {
 	Port int `yaml:"port"`
+}
+
+type DbCfg struct {
+	Path string `yaml:"path"`
 }
 
 type MissingPropertyError struct {
@@ -61,5 +84,5 @@ type MissingPropertyError struct {
 }
 
 func (e MissingPropertyError) Error() string {
-	return fmt.Sprintf("Property: '%s'. %s", e.Property, e.Message)
+	return fmt.Sprintf("%s: '%s'", e.Message, e.Property)
 }

--- a/internal/coffy/config_test.go
+++ b/internal/coffy/config_test.go
@@ -5,13 +5,39 @@ import (
 	"testing"
 )
 
+// Working configuration, must contain all config parameters
 var validConfig = `
+server:
+    port: 8080
+database:
+    path: ./coffy_path/coffy_machine.db
+`
+
+var missingServer = `
+database:
+    path: ./coffy_path/coffy_machine.db
+`
+
+var missingServerPort = `
+server: 
+    unknown: any
+database:
+    path: ./coffy_path/coffy_machine.db
+`
+
+var missingDatabase = `
 server:
     port: 8080
 `
 
-var missingServer = `
+var missingDatabasePath = `
+server:
+    port: 8080
+database:
+    unknown: any
 `
+
+var coffyDBpath = "./coffy_path/coffy_machine.db"
 
 func TestParse(t *testing.T) {
 	config, err := Parse(validConfig)
@@ -21,6 +47,9 @@ func TestParse(t *testing.T) {
 	}
 	if config.Server.Port != 8080 {
 		t.Errorf("invalid server port: %v", config.Server.Port)
+	}
+	if config.Database.Path != coffyDBpath {
+		t.Errorf("invalid database path: %v", config.Database.Path)
 	}
 
 }
@@ -36,5 +65,47 @@ func TestParseMissingServer(t *testing.T) {
 		t.Errorf("Expected missing property error, got: %v", err)
 		return
 	}
+}
 
+func TestParseMissingServerPort(t *testing.T) {
+	_, err := Parse(missingServerPort)
+	if err == nil {
+		t.Errorf("Expected error for missing server port")
+		return
+	}
+	var expectedErr = &MissingPropertyError{}
+	if !errors.As(err, expectedErr) {
+		t.Errorf("Expected missing property error, got: %v", err)
+		return
+	}
+	if err.Error() != "missing property: 'port'" {
+		t.Errorf("Expected message: missing property: 'port', got: %v", err)
+	}
+}
+
+func TestParseMissingDatabase(t *testing.T) {
+	_, err := Parse(missingDatabase)
+	if err == nil {
+		t.Errorf("Expected error for missing database config entry")
+	}
+	var expectedErr = &MissingPropertyError{}
+	if !errors.As(err, expectedErr) {
+		t.Errorf("Expected missing property error, got: %v", err)
+		return
+	}
+}
+
+func TestParseMissingDatabasePath(t *testing.T) {
+	_, err := Parse(missingDatabasePath)
+	if err == nil {
+		t.Errorf("Expected error for missing database config entry")
+	}
+	var expectedErr = &MissingPropertyError{}
+	if !errors.As(err, expectedErr) {
+		t.Errorf("Expected missing property error, got: %v", err)
+		return
+	}
+	if err.Error() != "missing property: 'path'" {
+		t.Errorf("Expected message: 'missing property: 'path'', got: %v", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -42,10 +42,11 @@ func startCoffy(config *coffy.Config) {
 	docs.SwaggerInfo.BasePath = "/api/v1"
 
 	// init the event repo
-	repo, err := storage.CreateEventRepository("test.db")
+	repo, err := storage.CreateEventRepository(config.Database.Path)
 	if err != nil {
 		log.Fatal(err)
 	}
+	log.Println("Database in use:", config.Database.Path)
 
 	// create app services first
 	accService := account.NewAccounting(&repo)
@@ -76,6 +77,7 @@ func startCoffy(config *coffy.Config) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	log.Println("Coffy Machine is running and listening on port", config.Server.Port)
 }
 
 func logStartup() {


### PR DESCRIPTION
Adds a new property `database` and `path` to the configuration.

The database file can now be configured by the user.